### PR TITLE
Add Asynchronous Initialization and Properly Connect to Wallet RPC When Using MoneroNetwork Enum

### DIFF
--- a/Daemon/MoneroDaemonClient.cs
+++ b/Daemon/MoneroDaemonClient.cs
@@ -37,6 +37,24 @@ namespace Monero.Client.Daemon
             _moneroRpcCommunicator = new RpcCommunicator(networkType, ConnectionType.Daemon);
         }
 
+        public static Task<MoneroDaemonClient> CreateAsync(Uri uri, CancellationToken cancellationToken = default)
+        {
+            var moneroDaemonClient = new MoneroDaemonClient(uri);
+            return moneroDaemonClient.InitializeAsync(cancellationToken);
+        }
+
+        public static Task<MoneroDaemonClient> CreateAsync(MoneroNetwork moneroNetwork, CancellationToken cancellationToken = default)
+        {
+            var moneroDaemonClient = new MoneroDaemonClient(moneroNetwork);
+            return moneroDaemonClient.InitializeAsync(cancellationToken);
+        }
+
+        private Task<MoneroDaemonClient> InitializeAsync(CancellationToken cancellationToken)
+        {
+            // Nothing to do yet.
+            return Task.FromResult(this);
+        }
+
         public void Dispose()
         {
             _moneroRpcCommunicator.Dispose();

--- a/Daemon/MoneroDaemonClient.cs
+++ b/Daemon/MoneroDaemonClient.cs
@@ -34,7 +34,7 @@ namespace Monero.Client.Daemon
         /// </summary>
         public MoneroDaemonClient(MoneroNetwork networkType)
         {
-            _moneroRpcCommunicator = new RpcCommunicator(networkType);
+            _moneroRpcCommunicator = new RpcCommunicator(networkType, ConnectionType.Daemon);
         }
 
         public void Dispose()

--- a/Network/MoneroNetwork.cs
+++ b/Network/MoneroNetwork.cs
@@ -7,14 +7,17 @@
     {
         /// <summary>
         /// Mainnet is the "production" network and blockchain.
+        /// Port 18082 for Wallet and port 18081 for Daemon.
         /// </summary>
         Mainnet,
         /// <summary>
         /// Stagenet is technically equivalent to mainnet, both in terms of features and consensus rules.
+        /// Port 38082 for Wallet and port 38081 for Daemon.
         /// </summary>
         Stagenet,
         /// <summary>
         /// Testnet is the "experimental" network and blockchain where things get released long before mainnet.
+        /// Port 28082 for Wallet and port 28081 for Daemon.
         /// </summary>
         Testnet,
     }

--- a/Network/RpcCommunicator.cs
+++ b/Network/RpcCommunicator.cs
@@ -59,43 +59,16 @@ namespace Monero.Client.Utilities
 
         public RpcCommunicator(MoneroNetwork networkType, ConnectionType connectionType) : this()
         {
-            Uri uri;
-            if (connectionType == ConnectionType.Daemon)
+            Uri uri = (connectionType, networkType) switch 
             {
-                switch (networkType)
-                {
-                    case MoneroNetwork.Mainnet:
-                        uri = new Uri(MoneroNetworkDefaults.DaemonMainnetUri);
-                        break;
-                    case MoneroNetwork.Stagenet:
-                        uri = new Uri(MoneroNetworkDefaults.DaemonStagenetUri);
-                        break;
-                    case MoneroNetwork.Testnet:
-                        uri = new Uri(MoneroNetworkDefaults.DaemonTestnetUri);
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType})");
-                }
-            }
-            else if (connectionType == ConnectionType.Wallet)
-            {
-                switch (networkType)
-                {
-                    case MoneroNetwork.Mainnet:
-                        uri = new Uri(MoneroNetworkDefaults.WalletMainnetUri);
-                        break;
-                    case MoneroNetwork.Stagenet:
-                        uri = new Uri(MoneroNetworkDefaults.WalletStagenetUri);
-                        break;
-                    case MoneroNetwork.Testnet:
-                        uri = new Uri(MoneroNetworkDefaults.WalletTestnetUri);
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType})");
-                }
-            }
-            else
-                throw new InvalidOperationException($"Unknown ConnectionType ({connectionType})");
+                (ConnectionType.Daemon, MoneroNetwork.Mainnet) => new Uri(MoneroNetworkDefaults.DaemonMainnetUri),
+                (ConnectionType.Daemon, MoneroNetwork.Stagenet) => new Uri(MoneroNetworkDefaults.DaemonStagenetUri),
+                (ConnectionType.Daemon, MoneroNetwork.Testnet) => new Uri(MoneroNetworkDefaults.DaemonTestnetUri),
+                (ConnectionType.Wallet, MoneroNetwork.Mainnet) => new Uri(MoneroNetworkDefaults.WalletMainnetUri),
+                (ConnectionType.Wallet, MoneroNetwork.Stagenet) => new Uri(MoneroNetworkDefaults.WalletStagenetUri),
+                (ConnectionType.Wallet, MoneroNetwork.Testnet) => new Uri(MoneroNetworkDefaults.WalletTestnetUri),
+                (_, _) => throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType}) and ConnectionType ({connectionType}) combination"),
+            };
             _requestAdapter = new MoneroRequestAdapter(uri);
         }
 

--- a/Network/RpcCommunicator.cs
+++ b/Network/RpcCommunicator.cs
@@ -15,6 +15,12 @@ using System.Threading.Tasks;
 
 namespace Monero.Client.Utilities
 {
+    internal enum ConnectionType
+    {
+        Wallet,
+        Daemon,
+    }
+
     internal class RpcCommunicator
     {
         private readonly HttpClient _httpClient;
@@ -51,23 +57,45 @@ namespace Monero.Client.Utilities
             _requestAdapter = new MoneroRequestAdapter(uri);
         }
 
-        public RpcCommunicator(MoneroNetwork networkType) : this()
+        public RpcCommunicator(MoneroNetwork networkType, ConnectionType connectionType) : this()
         {
             Uri uri;
-            switch (networkType)
+            if (connectionType == ConnectionType.Daemon)
             {
-                case MoneroNetwork.Mainnet:
-                    uri = new Uri(MoneroNetworkDefaults.DaemonMainnetUri);
-                    break;
-                case MoneroNetwork.Stagenet:
-                    uri = new Uri(MoneroNetworkDefaults.DaemonStagenetUri);
-                    break;
-                case MoneroNetwork.Testnet:
-                    uri = new Uri(MoneroNetworkDefaults.DaemonTestnetUri);
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType})");
+                switch (networkType)
+                {
+                    case MoneroNetwork.Mainnet:
+                        uri = new Uri(MoneroNetworkDefaults.DaemonMainnetUri);
+                        break;
+                    case MoneroNetwork.Stagenet:
+                        uri = new Uri(MoneroNetworkDefaults.DaemonStagenetUri);
+                        break;
+                    case MoneroNetwork.Testnet:
+                        uri = new Uri(MoneroNetworkDefaults.DaemonTestnetUri);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType})");
+                }
             }
+            else if (connectionType == ConnectionType.Wallet)
+            {
+                switch (networkType)
+                {
+                    case MoneroNetwork.Mainnet:
+                        uri = new Uri(MoneroNetworkDefaults.WalletMainnetUri);
+                        break;
+                    case MoneroNetwork.Stagenet:
+                        uri = new Uri(MoneroNetworkDefaults.WalletStagenetUri);
+                        break;
+                    case MoneroNetwork.Testnet:
+                        uri = new Uri(MoneroNetworkDefaults.WalletTestnetUri);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown MoneroNetwork ({networkType})");
+                }
+            }
+            else
+                throw new InvalidOperationException($"Unknown ConnectionType ({connectionType})");
             _requestAdapter = new MoneroRequestAdapter(uri);
         }
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ using Monero.Client.Network;
 using Monero.Client.Wallet;
 using Monero.Client.Wallet.POD;
 
-var moneroWalletClient = new MoneroWalletClient(MoneroNetwork.Testnet);
+// Synchronously Initialize Client
+var moneroWalletClient = new MoneroWalletClient(new Uri("http://127.0.0.1:18082/json_rpc"));
+
+// Asynchronously Initialize Client (and Open Wallet) - This is the preferred method of initialization.
+var walletClient = await MoneroWalletClient.CreateAsync(MoneroNetwork.Mainnet, "TestMainnet", "123").ConfigureAwait(false);
 ```
 **Open Wallet**
 ```csharp
+// Will throw if wallet is already open.
 await moneroWalletClient.OpenWalletAsync("new_wallet3", "banana").ConfigureAwait(false);
 ```
 **Transfer Funds**
@@ -42,7 +47,7 @@ var dA = new List<(string address, ulong amount)>()
 };
 var response = await moneroWalletClient.TransferAsync(dA, TransferPriority.Normal, cts.token).ConfigureAwait(false);
 ```
-For the entire MoneroWalletClient interface, please click [here](https://github.com/Agorist-Action/csharp-monero-rpc-client/blob/master/Wallet/IMoneroWalletClient.cs).
+For the entire MoneroWalletClient interface, please click [here](https://github.com/monero-ecosystem/csharp-monero-rpc-client/blob/master/Wallet/IMoneroWalletClient.cs).
 **Note:** Unlike the Daemon Client, to perform any action with the Wallet Client, one must first either create a new wallet, or open an existing one (as shown above).
 # Latest Stable Release
 Available on Nuget [here](https://www.nuget.org/packages/Monero.Client/).
@@ -51,7 +56,7 @@ Install-Package Monero.Client -Version 1.0.1.3
 ```
 # Latest Development Changes
 ```
-git clone https://github.com/Agorist-Action/csharp-monero-rpc-client
+git clone https://github.com/monero-ecosystem/csharp-monero-rpc-client.git
 ```
 # Contributing
 All contributions are welcome. Please make sure your pull request include:

--- a/Wallet/MoneroWalletClient.cs
+++ b/Wallet/MoneroWalletClient.cs
@@ -37,6 +37,27 @@ namespace Monero.Client.Wallet
             _moneroRpcCommunicator = new RpcCommunicator(networkType, ConnectionType.Wallet);
         }
 
+        /// <summary>
+        /// Initialize a Monero Wallet Client using default network settings (<localhost>:<defaultport>), opening the wallet while doing so.
+        /// </summary>
+        public static Task<MoneroWalletClient> CreateAsync(Uri uri, string filename, string password, CancellationToken cancellationToken = default)
+        {
+            var moneroWalletClient = new MoneroWalletClient(uri);
+            return moneroWalletClient.InitializeAsync(filename, password, cancellationToken);
+        }
+
+        public static Task<MoneroWalletClient> CreateAsync(MoneroNetwork networkType, string filename, string password, CancellationToken cancellationToken = default)
+        {
+            var moneroWalletClient = new MoneroWalletClient(networkType);
+            return moneroWalletClient.InitializeAsync(filename, password, cancellationToken);
+        }
+
+        private async Task<MoneroWalletClient> InitializeAsync(string filename, string password, CancellationToken cancellationToken)
+        {
+            await OpenWalletAsync(filename, password, cancellationToken).ConfigureAwait(false);
+            return this;
+        }
+
         public void Dispose()
         {
             this.CloseWalletAsync().GetAwaiter().GetResult();

--- a/Wallet/MoneroWalletClient.cs
+++ b/Wallet/MoneroWalletClient.cs
@@ -34,7 +34,7 @@ namespace Monero.Client.Wallet
         /// </summary>
         public MoneroWalletClient(MoneroNetwork networkType)
         {
-            _moneroRpcCommunicator = new RpcCommunicator(networkType);
+            _moneroRpcCommunicator = new RpcCommunicator(networkType, ConnectionType.Wallet);
         }
 
         public void Dispose()


### PR DESCRIPTION
- Add Asynchronous API to DaemonClient and WalletClient Creation. WalletClient's asynchronous initialization does work, opening the wallet so we don't need two separate calls (one to contructor, one to OpenWalletAsync). See use in ReadMe.MD
- Properly connect to default MoneroWallet hostname and port. Previously when the wallet client was initialized with MoneroNetwork (e.g. MoneroNetwork.Mainnet), it used the Daemon's default address.

@rbrunner7 