### PR TITLE
Eliminated variable setting side effect in 'GetTransfersAsync'

### DIFF
--- a/Network/RpcCommunicator.cs
+++ b/Network/RpcCommunicator.cs
@@ -856,7 +856,7 @@ namespace Monero.Client.Utilities
         public Task<MoneroCommunicatorResponse> GetTransfersAsync(bool @in, bool @out, bool pending, bool failed, bool pool, CancellationToken token = default)
         {
             bool isValidRequest = false;
-            isValidRequest |= @in |= @out |= pending |= failed |= pool;
+            isValidRequest = @in | @out | pending | failed | pool;
             if (!isValidRequest)
                 throw new InvalidOperationException("Not requesting to view any form of transfer");
             var GenericRequestParameters = new GenericRequestParameters()
@@ -873,7 +873,7 @@ namespace Monero.Client.Utilities
         public Task<MoneroCommunicatorResponse> GetTransfersAsync(bool @in, bool @out, bool pending, bool failed, bool pool, uint min_height, uint max_height, CancellationToken token = default)
         {
             bool isValidRequest = false;
-            isValidRequest |= @in |= @out |= pending |= failed |= pool;
+            isValidRequest = @in | @out | pending | failed | pool;
             if (!isValidRequest)
                 throw new InvalidOperationException("Not requesting to view any form of transfer");
             if (max_height < min_height)


### PR DESCRIPTION
This is a cute little bug that took me a while to understand: With e.g. `pending` as true the variables `in` and `out` get set to true as an unwanted side effect with the current checking statements.