### PR TITLE
Specify Meaning of Return Types of Functions in Documentation

### DIFF
--- a/Daemon/MoneroDaemonClient.cs
+++ b/Daemon/MoneroDaemonClient.cs
@@ -157,6 +157,7 @@ namespace Monero.Client.Daemon
         /// Flush tx ids from transaction pool
         /// </summary>
         /// <param name="txids">List of transactions IDs to flush from pool (all tx ids flushed if empty).</param>
+        /// <returns>A string representing transaction pool status.</returns>
         public async Task<string> FlushTransactionPoolAsync(IEnumerable<string> txids, CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.FlushTransactionPoolAsync(txids, token).ConfigureAwait(false);
@@ -227,6 +228,7 @@ namespace Monero.Client.Daemon
         /// <summary>
         /// Relay a transaction.
         /// </summary>
+        /// <returns>The transaction hash of the relayed transaction.</returns>
         public async Task<string> RelayTransactionAsync(string hex, CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.RelayTransactionAsync(hex, token).ConfigureAwait(false);
@@ -269,6 +271,7 @@ namespace Monero.Client.Daemon
         /// <summary>
         /// Ban a node by IP.
         /// </summary>
+        /// <returns>A string representing the banned node's status.</returns>
         public async Task<string> SetBansAsync(IEnumerable<(string host, ulong ip, bool ban, uint seconds)> bans, CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.SetBansAsync(bans, token).ConfigureAwait(false);

--- a/Wallet/MoneroWalletClient.cs
+++ b/Wallet/MoneroWalletClient.cs
@@ -539,6 +539,7 @@ namespace Monero.Client.Wallet
         /// <summary>
         /// Export outputs in hex format.
         /// </summary>
+        /// <returns>Output data hex.</returns>
         public async Task<string> ExportOutputsAsync(CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.ExportOutputsAsync(token).ConfigureAwait(false);
@@ -585,6 +586,7 @@ namespace Monero.Client.Wallet
         /// <param name="recipientName">Name of the payment recipient.</param>
         /// <param name="txDescription">Description of the reason for the tx.</param>
         /// <param name="paymentId">16 or 64 character hexadecimal payment id.</param>
+        /// <returns>Payment URI.</returns>
         public async Task<string> MakeUriAsync(string address, ulong amount, string recipientName, string txDescription = null, string paymentId = null, CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.MakeUriAsync(address, amount, recipientName, txDescription, paymentId, token).ConfigureAwait(false);
@@ -744,6 +746,7 @@ namespace Monero.Client.Wallet
         /// <summary>
         /// Export multisig info for other participants.
         /// </summary>
+        /// <returns>A string representing multisig information.</returns>
         public async Task<string> ExportMultiSigInfoAsync(CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.ExportMultiSigInfoAsync(token).ConfigureAwait(false);
@@ -767,6 +770,7 @@ namespace Monero.Client.Wallet
         /// </summary>
         /// <param name="multisigInfo">List of multisig string from peers.</param>
         /// <param name="password">Wallet password.</param>
+        /// <returns>The multisig wallet address.</returns>
         public async Task<string> FinalizeMultiSigAsync(IEnumerable<string> multiSigInfo, string password, CancellationToken token = default)
         {
             var result = await _moneroRpcCommunicator.FinalizeMultiSigAsync(multiSigInfo, password, token).ConfigureAwait(false);


### PR DESCRIPTION
Some functions return a primitive type.

I added documentation specifying what the return type actually represents, which may be hard to discern if one doesn't look at the code. Other functions that return a user-defined type like `SaveWallet` have their return type's meaning implied in their type name.