### PR TITLE
Implement attribute calls

### DIFF
--- a/Network/GenericRequestParameters.cs
+++ b/Network/GenericRequestParameters.cs
@@ -87,5 +87,7 @@ namespace Monero.Client.Network
         public bool? binary { get; set; } = null;
         public bool? compress { get; set; } = null;
         public bool? check { get; set; } = null;
+        public string key { get; set; } = null;
+        public string value { get; set; } = null;
     }
 }

--- a/Network/MoneroCommunicatorResponse.cs
+++ b/Network/MoneroCommunicatorResponse.cs
@@ -112,6 +112,8 @@ namespace Monero.Client.Network
         DescribeTransfer,
         SweepSingle,
         GetPaymentDetail,
+        GetAttribute,
+        SetAttribute
     }
 
     internal class MoneroCommunicatorResponse
@@ -205,5 +207,7 @@ namespace Monero.Client.Network
         internal DescribeTransferResponse DescribeTransferResponse { get; set; }
         internal SweepSingleResponse SweepSingleResponse { get; set; }
         internal PaymentDetailResponse PaymentDetailResponse { get; set; }
+        internal SetAttributeResponse SetAttributeResponse { get; set; }
+        internal GetAttributeResponse GetAttributeResponse { get; set; }
     }
 }

--- a/Network/MoneroRequestAdapter.cs
+++ b/Network/MoneroRequestAdapter.cs
@@ -449,6 +449,16 @@ namespace Monero.Client.Network
                     method = "prune_blockchain",
                     @params = requestParams,
                 },
+                MoneroResponseSubType.GetAttribute => new GenericRequest
+                {
+                    method = "get_attribute",
+                    @params = requestParams,
+                },
+                MoneroResponseSubType.SetAttribute => new GenericRequest
+                {
+                    method = "set_attribute",
+                    @params = requestParams,
+                },
                 MoneroResponseSubType.Verify => throw new NotImplementedException("The Verify RPC Command is not implemented"),
                 _ => throw new InvalidOperationException($"Unknown MoneroDaemonResponseSubType ({subType})"),
             };

--- a/Network/RpcCommunicator.cs
+++ b/Network/RpcCommunicator.cs
@@ -1935,6 +1935,45 @@ namespace Monero.Client.Utilities
             };
         }
 
+        public async Task<MoneroCommunicatorResponse> SetAttributeAsync(string key, string value, CancellationToken token = default)
+        {
+            var daemonRequestParameters = new GenericRequestParameters()
+            {
+                key = key,
+                value = value,
+            };
+            HttpRequestMessage request = await _requestAdapter.GetRequestMessage(MoneroResponseSubType.SetAttribute, daemonRequestParameters, token).ConfigureAwait(false);
+            HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, token).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            using Stream ms = await ByteArrayToMemoryStream(response).ConfigureAwait(false);
+            SetAttributeResponse responseObject = await JsonSerializer.DeserializeAsync<SetAttributeResponse>(ms, _defaultSerializationOptions, token).ConfigureAwait(false);
+            return new MoneroCommunicatorResponse()
+            {
+                MoneroResponseType = MoneroResponseType.Wallet,
+                MoneroResponseSubType = MoneroResponseSubType.SetAttribute,
+                SetAttributeResponse = responseObject,
+            };
+        }
+
+        public async Task<MoneroCommunicatorResponse> GetAttributeAsync(string key, CancellationToken token = default)
+        {
+            var daemonRequestParameters = new GenericRequestParameters()
+            {
+                key = key,
+            };
+            HttpRequestMessage request = await _requestAdapter.GetRequestMessage(MoneroResponseSubType.GetAttribute, daemonRequestParameters, token).ConfigureAwait(false);
+            HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, token).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            using Stream ms = await ByteArrayToMemoryStream(response).ConfigureAwait(false);
+            GetAttributeResponse responseObject = await JsonSerializer.DeserializeAsync<GetAttributeResponse>(ms, _defaultSerializationOptions, token).ConfigureAwait(false);
+            return new MoneroCommunicatorResponse()
+            {
+                MoneroResponseType = MoneroResponseType.Wallet,
+                MoneroResponseSubType = MoneroResponseSubType.GetAttribute,
+                GetAttributeResponse = responseObject,
+            };
+        }
+
         public void Dispose()
         {
             _httpClient.Dispose();

--- a/Wallet/IMoneroWalletClient.cs
+++ b/Wallet/IMoneroWalletClient.cs
@@ -83,5 +83,7 @@ namespace Monero.Client.Wallet
         Task<SignMultiSigTransaction> SignMultiSigAsync(string txDataHex, CancellationToken token = default);
         Task<List<string>> SubmitMultiSigAsync(string txDataHex, CancellationToken token = default);
         Task<List<PaymentDetail>> GetPaymentDetailAsync(string paymentId, CancellationToken token = default);
+        Task SetAttributeAsync(string key, string value, CancellationToken token = default);
+        Task<string> GetAttributeAsync(string key, CancellationToken token = default);
     }
 }

--- a/Wallet/MoneroWalletClient.cs
+++ b/Wallet/MoneroWalletClient.cs
@@ -862,5 +862,24 @@ namespace Monero.Client.Wallet
             ErrorGuard.ThrowIfResultIsNull(result?.PaymentDetailResponse, nameof(GetPaymentDetailAsync));
             return result.PaymentDetailResponse.Result.Payments;
         }
+
+        /// <summary>
+        /// Set an attribute (key/value pair) to store any additional info in the wallet
+        /// </summary>
+        public async Task SetAttributeAsync(string key, string value, CancellationToken token = default)
+        {
+            var result = await _moneroRpcCommunicator.SetAttributeAsync(key, value, token).ConfigureAwait(false);
+            ErrorGuard.ThrowIfResultIsNull(result?.SetAttributeResponse, nameof(SetAttributeAsync));
+        }
+
+        /// <summary>
+        /// Get an attribute value from the wallet, given its key; throws an error if not present
+        /// </summary>
+        public async Task<string> GetAttributeAsync(string key, CancellationToken token = default)
+        {
+            var result = await _moneroRpcCommunicator.GetAttributeAsync(key, token).ConfigureAwait(false);
+            ErrorGuard.ThrowIfResultIsNull(result?.GetAttributeResponse, nameof(GetAttributeAsync));
+            return result.GetAttributeResponse.Result.Value;
+        }
     }
 }

--- a/Wallet/POD/Responses/GetAttributeResponse.cs
+++ b/Wallet/POD/Responses/GetAttributeResponse.cs
@@ -1,0 +1,21 @@
+﻿using Monero.Client.Network;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Wallet.POD.Responses
+{
+    internal class GetAttributeResponse : RpcResponse
+    {
+        [JsonPropertyName("result")]
+        public GetAttributeResult Result { get; set; }
+    }
+
+    internal class GetAttributeResult
+    {
+        [JsonPropertyName("value")]
+        public string Value { get; set; }
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
+}

--- a/Wallet/POD/Responses/SetAttributeResponse.cs
+++ b/Wallet/POD/Responses/SetAttributeResponse.cs
@@ -1,0 +1,16 @@
+﻿using Monero.Client.Network;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Wallet.POD.Responses
+{
+    internal class SetAttributeResponse : RpcResponse
+    {
+        [JsonPropertyName("result")]
+        public GetAttributeResult Result { get; set; }
+    }
+
+    internal class SetAttributeResult
+    {
+        // Empty
+    }
+}


### PR DESCRIPTION
Currently these calls are most useful to get and set the wallet description, using the predefined key `wallet2.description`.

But in more complicated applications it may be useful to be able to store additional, application-specific info directly into the wallet file itself, where it is in no danger to get lost.