### PR TITLE
Correct JsonPropertyName at 'FundTransferResponse'

### DIFF
--- a/Wallet/POD/Responses/FundTransferResponse.cs
+++ b/Wallet/POD/Responses/FundTransferResponse.cs
@@ -6,7 +6,7 @@ namespace Monero.Client.Wallet.POD.Responses
 {
     internal class FundTransferResponse : RpcResponse
     {
-        [JsonPropertyName("address")]
+        [JsonPropertyName("result")]
         public FundTransfer Result { get; set; }
     }
 


### PR DESCRIPTION
That typo / bad copy artefact was somewhat hard to find :)

I checked all the other wallet response types, they are all clean in this regard i.e. no other wallet response class has the same error.