### PR TITLE
Add get_transaction_pool and get_transactions Calls to DaemonClient

### DIFF
--- a/Daemon/IMoneroDaemonClient.cs
+++ b/Daemon/IMoneroDaemonClient.cs
@@ -33,7 +33,8 @@ namespace Monero.Client.Daemon
         Task<string> SetBansAsync(IEnumerable<(string host, ulong ip, bool ban, uint seconds)> bans, CancellationToken token = default);
         Task<bool> SubmitBlocksAsync(IEnumerable<string> blockBlob, CancellationToken token = default);
         Task<BlockTemplate> GetBlockTemplateAsync(ulong reserveSize, string walletAddress, string prevBlock = null, string extraNonce = null, CancellationToken token = default);
-        //Task<PruneBlockchain> PruneBlockchainAsync(bool check = false, CancellationToken token = default);
         Task<TransactionPoolBacklog> GetTransactionPoolBacklogAsync(CancellationToken token = default);
+        Task<TransactionPool> GetTransactionPoolAsync(CancellationToken token = default);
+        Task<List<Transaction>> GetTransactionsAsync(IEnumerable<string> txHashes, CancellationToken token = default);
     }
 }

--- a/Daemon/POD/BlockDetails.cs
+++ b/Daemon/POD/BlockDetails.cs
@@ -27,7 +27,7 @@ namespace Monero.Client.Daemon.POD
         {
             get
             {
-                return new DateTime(1970, 1, 1).AddSeconds(Timestamp);
+                return DateTime.UnixEpoch.AddSeconds(this.Timestamp);
             }
         }
         public override string ToString()

--- a/Daemon/POD/BlockHeader.cs
+++ b/Daemon/POD/BlockHeader.cs
@@ -55,7 +55,7 @@ namespace Monero.Client.Daemon.POD
         {
             get
             {
-                return new DateTime(1970, 1, 1).AddSeconds(this.Timestamp);
+                return DateTime.UnixEpoch.AddSeconds(this.Timestamp);
             }
         }
         public override string ToString()

--- a/Daemon/POD/Responses/GetTransactionsResponse.cs
+++ b/Daemon/POD/Responses/GetTransactionsResponse.cs
@@ -1,0 +1,28 @@
+﻿using Monero.Client.Network;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD.Responses
+{
+    public class TransactionSet
+    {
+        [JsonPropertyName("credits")]
+        public ulong Credits { get; set; }
+        [JsonPropertyName("top_hash")]
+        public string TopHash { get; set; }
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+        [JsonPropertyName("txs")]
+        public List<Transaction> Transactions { get; set; } = new List<Transaction>();
+        [JsonPropertyName("txs_as_hex")]
+        public List<string> TxsAsHex { get; set; } = new List<string>();
+        [JsonPropertyName("untrusted")]
+        public bool Untrusted { get; set; }
+        public override string ToString()
+        {
+            return $"Tx Count: {Transactions.Count}";
+        }
+    }
+}

--- a/Daemon/POD/SpentKeyImage.cs
+++ b/Daemon/POD/SpentKeyImage.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD
+{
+    public class SpentKeyImage
+    {
+        [JsonPropertyName("id_hash")]
+        public string KeyImage { get; set; }
+        [JsonPropertyName("txs_hashes")]
+        public List<string> TxHashes { get; set; } = new List<string>();
+        public override string ToString()
+        {
+            return KeyImage;
+        }
+    }
+}

--- a/Daemon/POD/Transaction.cs
+++ b/Daemon/POD/Transaction.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD
+{
+    public class Transaction
+    {
+        [JsonPropertyName("as_hex")]
+        public string AsHex { get; set; }
+        [JsonPropertyName("as_json")]
+        public string AsJson { get; set; }
+        [JsonPropertyName("prunable_as_hex")]
+        public string PrunableAsHex { get; set; }
+        [JsonPropertyName("prunable_hash")]
+        public string PrunableHash { get; set; }
+        [JsonPropertyName("pruned_as_hex")]
+        public string PrunedAsHex { get; set; }
+        [JsonPropertyName("double_spend_seen")]
+        public bool IsDoubleSpendSeen { get; set; }
+        [JsonPropertyName("in_pool")]
+        public bool InPool { get; set; }
+        [JsonPropertyName("tx_hash")]
+        public string TxHash { get; set; }
+        [JsonPropertyName("block_height")]
+        public ulong Height { get; set; }
+        [JsonPropertyName("block_timestamp")]
+        public ulong Timestamp { get; set; }
+        [JsonIgnore()]
+        public DateTime DateTime
+        {
+            get
+            {
+                return DateTime.UnixEpoch.AddSeconds(this.Timestamp);
+            }
+        }
+        public override string ToString()
+        {
+            return TxHash;
+        }
+    }
+}

--- a/Daemon/POD/TransactionDetails.cs
+++ b/Daemon/POD/TransactionDetails.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD
+{
+    public class TransactionDetails
+    {
+        [JsonPropertyName("version")]
+        public uint Version { get; set; }
+        [JsonPropertyName("unlock_time")]
+        public ulong UnlockTime { get; set; }
+    }
+}

--- a/Daemon/POD/TransactionPool.cs
+++ b/Daemon/POD/TransactionPool.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD
+{
+    public class TransactionPool
+    {
+        [JsonPropertyName("credits")]
+        public ulong Credits { get; set; }
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+        [JsonPropertyName("top_hash")]
+        public string TopHash { get; set; }
+        [JsonPropertyName("spent_key_images")]
+        public List<SpentKeyImage> SpentKeyImages { get; set; } = new List<SpentKeyImage>();
+        [JsonPropertyName("transactions")]
+        public List<TransactionPoolTransaction> Transactions { get; set; } = new List<TransactionPoolTransaction>();
+        [JsonPropertyName("untrusted")]
+        public bool Untrusted { get; set; }
+        public override string ToString()
+        {
+            return $"Tx Count: {this.Transactions.Count}";
+        }
+    }
+}

--- a/Daemon/POD/TransactionPoolTransaction.cs
+++ b/Daemon/POD/TransactionPoolTransaction.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Daemon.POD
+{
+    public class TransactionPoolTransaction
+    {
+        [JsonPropertyName("blob_size")]
+        public ulong BlobSize { get; set; }
+        [JsonPropertyName("double_spend_seen")]
+        public bool IsDoubleSpendSeen { get; set; }
+        [JsonPropertyName("do_not_relay")]
+        public bool DoNotRelay { get; set; }
+        [JsonPropertyName("fee")]
+        public ulong Fee { get; set; }
+        [JsonPropertyName("id_hash")]
+        public string TxHash { get; set; }
+        [JsonPropertyName("kept_by_block")]
+        public bool KeptByBlock { get; set; }
+        [JsonPropertyName("last_failed_height")]
+        public ulong LastFailedHeight { get; set; }
+        [JsonIgnore()]
+        public bool PreviouslyFailed
+        {
+            get
+            {
+                const string defaultIdHash = "0000000000000000000000000000000000000000000000000000000000000000";
+                const ulong defaultHeight = 0;
+                return LastFailedHeight != defaultHeight && 
+                    string.Compare(defaultIdHash, LastFailedTxHash) != 0;
+            }
+        }
+        [JsonPropertyName("last_failed_id_hash")]
+        public string LastFailedTxHash { get; set; }
+        [JsonPropertyName("last_relayed_time")]
+        public ulong LastRelayedTime { get; set; }
+        [JsonIgnore()]
+        public DateTime LastRelayDateTime
+        {
+            get
+            {
+                return DateTime.UnixEpoch.AddSeconds(LastRelayedTime);
+            }
+        }
+        [JsonPropertyName("max_used_block_height")]
+        public ulong MaxUsedBlockHeight { get; set; }
+        [JsonPropertyName("max_used_block_id_hash")]
+        public string MaxUsedBlockTxHash { get; set; }
+        [JsonPropertyName("receive_time")]
+        public ulong ReceiveTime { get; set; }
+        [JsonIgnore()]
+        public DateTime ReceiveDateTime
+        {
+            get
+            {
+                return DateTime.UnixEpoch.AddSeconds(ReceiveTime);
+            }
+        }
+        [JsonPropertyName("relayed")]
+        public bool Relayed { get; set; }
+        [JsonPropertyName("tx_blob")]
+        public string TxBlob { get; set; }
+        [JsonPropertyName("tx_json")]
+        public string TxJson { get; set; }
+        [JsonPropertyName("weight")]
+        public ulong Weight { get; set; }
+        public override string ToString()
+        {
+            return TxHash;
+        }
+
+        // As Json
+        //public class TransactionPoolTransactionAsJson
+        //{
+        //    [JsonPropertyName("version")]
+        //    public uint Version { get; set; }
+        //    [JsonPropertyName("unlock_time")]
+        //    public ulong UnlockTime { get; set; }
+        //    [JsonPropertyName("version")]
+        //}
+    }
+}

--- a/Network/BaseRequest.cs
+++ b/Network/BaseRequest.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Monero.Client.Network
+{
+    internal class BaseRequest : Request
+    {
+        public string method { get; set; }
+        public GenericRequestParameters @params { get; set; }
+    }
+
+    internal class CustomRequest : BaseRequest
+    {
+        /// <summary>
+        /// Not all requests use the json_rpc interface. Those that don't need custom to pass arguments
+        /// directly instead of via params.
+        /// </summary>
+        public IEnumerable<string> txs_hashes { get; set; } = null;
+    }
+}

--- a/Network/GenericRequest.cs
+++ b/Network/GenericRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace Monero.Client.Network
-{
-    internal class GenericRequest : Request
-    {
-        public string method { get; set; }
-        public GenericRequestParameters @params { get; set; }
-    }
-}

--- a/Network/GenericRequestParameters.cs
+++ b/Network/GenericRequestParameters.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 
 namespace Monero.Client.Network
 {
+    /// <summary>
+    /// Used for json_rpc interface commands.
+    /// </summary>
     internal class GenericRequestParameters
     {
         public ulong? height { get; set; } = null;
@@ -89,5 +92,13 @@ namespace Monero.Client.Network
         public bool? check { get; set; } = null;
         public string key { get; set; } = null;
         public string value { get; set; } = null;
+    }
+
+    /// <summary>
+    /// Used for non json_rpc interface commands.
+    /// </summary>
+    internal class CustomRequestParameters : GenericRequestParameters
+    {
+        public IEnumerable<string> txs_hashes { get; set; } = null;
     }
 }

--- a/Network/MoneroCommunicatorResponse.cs
+++ b/Network/MoneroCommunicatorResponse.cs
@@ -1,4 +1,5 @@
 ﻿
+using Monero.Client.Daemon.POD;
 using Monero.Client.Daemon.POD.Responses;
 using Monero.Client.Wallet.POD.Responses;
 
@@ -51,6 +52,8 @@ namespace Monero.Client.Network
         GetBanStatus, // Status on the ban of an address.
         PruneBlockchain,
         TransactionPoolBacklog,
+        Transactions,
+        TransactionPoolTransactions,
 
         // Wallet
         Balance,
@@ -145,6 +148,8 @@ namespace Monero.Client.Network
         internal GetBlockTemplateResponse GetBlockTemplateResponse { get; set; }
         internal GetBanStatusResponse GetBanStatusResponse { get; set; }
         internal PruneBlockchainResponse PruneBlockchainResponse { get; set; }
+        internal TransactionSet TransactionsResponse { get; set; }
+        internal TransactionPool TransactionPoolResponse { get; set; }
         ///
         /// Wallet-related responses.
         ///

--- a/Network/MoneroNetworkDefaults.cs
+++ b/Network/MoneroNetworkDefaults.cs
@@ -4,12 +4,18 @@ namespace Monero.Client.Network
 {
     internal static class MoneroNetworkDefaults
     {
-        public const string DaemonMainnetUri = @"http://127.0.0.1:18081/json_rpc";
-        public const string DaemonStagenetUri = @"http://127.0.0.1:38081/json_rpc";
-        public const string DaemonTestnetUri = @"http://127.0.0.1:28081/json_rpc";
-        public const string WalletMainnetUri = @"http://127.0.0.1:18082/json_rpc";
-        public const string WalletStagenetUri = @"http://127.0.0.1:38082/json_rpc";
-        public const string WalletTestnetUri = @"http://127.0.0.1:28082/json_rpc";
+        public const string DaemonMainnetUrl = @"127.0.0.1";
+        public const uint DaemonMainnetPort = 18081;
+        public const string DaemonStagenetUrl = @"127.0.0.1";
+        public const uint DaemonStagenetPort = 38081;
+        public const string DaemonTestnetUrl = @"127.0.0.1";
+        public const uint DaemonTestnetPort = 28081;
+        public const string WalletMainnetUrl = @"127.0.0.1";
+        public const uint WalletMainnetPort = 18082;
+        public const string WalletStagenetUrl = @"127.0.0.1";
+        public const uint WalletStagenetPort = 38082;
+        public const string WalletTestnetUrl = @"127.0.0.1";
+        public const uint WalletTestnetPort = 28082;
     }
 
     internal static class FieldAndHeaderDefaults

--- a/Network/MoneroRequestAdapter.cs
+++ b/Network/MoneroRequestAdapter.cs
@@ -10,25 +10,37 @@ namespace Monero.Client.Network
 {
     internal class MoneroRequestAdapter
     {
-        private readonly Uri _uri;
+        private readonly string _url;
+        private readonly uint _port;
         private static readonly JsonSerializerOptions _defaultSerializationOptions = new JsonSerializerOptions() { IgnoreNullValues = true, };
 
-        public MoneroRequestAdapter(Uri uri)
+        public MoneroRequestAdapter(string url, uint port)
         {
-            _uri = uri;
+            _url = url;
+            _port = port;
+        }
+
+        public Task<HttpRequestMessage> GetRequestMessage(MoneroResponseSubType subType, CustomRequestParameters requestParams, CancellationToken token)
+        {
+            var request = GetRequest(subType, requestParams);
+            IUriBuilder uriBuilder = new UriBuilderDirector(new UriBuilder(_url, _port, RequestEndpointExtensionRetriever.FetchEndpoint(request)));
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uriBuilder.Build());
+            return SerializeRequest(httpRequestMessage, request, token);
         }
 
         public Task<HttpRequestMessage> GetRequestMessage(MoneroResponseSubType subType, GenericRequestParameters requestParams, CancellationToken token)
         {
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _uri);
             var request = GetRequest(subType, requestParams);
+            IUriBuilder uriBuilder = new UriBuilderDirector(new UriBuilder(_url, _port, RequestEndpointExtensionRetriever.FetchEndpoint(request)));
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uriBuilder.Build());
             return SerializeRequest(httpRequestMessage, request, token);
         }
 
         public Task<HttpRequestMessage> GetRequestMessage(MoneroResponseSubType subType, dynamic requestParams, CancellationToken token)
         {
-            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, _uri);
             AnonymousRequest request = GetRequest(subType, requestParams);
+            IUriBuilder uriBuilder = new UriBuilderDirector(new UriBuilder(_url, _port, RequestEndpointExtensionRetriever.FetchEndpoint(request)));
+            HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uriBuilder.Build());
             return SerializeRequest(httpRequestMessage, request, token);
         }
 
@@ -38,16 +50,19 @@ namespace Monero.Client.Network
             {
                 MoneroResponseSubType.DeleteAddressBook => new AnonymousRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "delete_address_book",
                     @params = requestParams,
                 },
                 MoneroResponseSubType.CheckTransactionKey => new AnonymousRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "check_tx_key",
                     @params = requestParams,
                 },
                 MoneroResponseSubType.SubmitBlock => new AnonymousRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "submit_block",
                     @params = requestParams,
                 },
@@ -55,407 +70,512 @@ namespace Monero.Client.Network
             };
         }
 
-        private static GenericRequest GetRequest(MoneroResponseSubType subType, GenericRequestParameters requestParams)
+        private static CustomRequest GetRequest(MoneroResponseSubType subType, CustomRequestParameters customRequest)
         {
             return subType switch
             {
-                MoneroResponseSubType.BlockCount => new GenericRequest
+                MoneroResponseSubType.Transactions => new CustomRequest
                 {
+                    endpoint = RequestEndpoint.Transactions,
+                    method = null,
+                    @params = null,
+                    txs_hashes = customRequest.txs_hashes,
+                    id = null,
+                    jsonrpc = null,
+                },
+                MoneroResponseSubType.TransactionPoolTransactions => new CustomRequest
+                {
+                    endpoint = RequestEndpoint.TransactionPool,
+                    method = null,
+                    @params = null,
+                    id = null,
+                    jsonrpc = null,
+                },
+                _ => throw new InvalidOperationException($"Unknown MoneroDaemonResponseSubType ({subType})"),
+            };
+        }
+
+        private static BaseRequest GetRequest(MoneroResponseSubType subType, GenericRequestParameters requestParams)
+        {
+            return subType switch
+            {
+                MoneroResponseSubType.BlockCount => new BaseRequest
+                {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block_count",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.BlockHeaderByHash => new GenericRequest
+                MoneroResponseSubType.BlockHeaderByHash => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block_header_by_hash",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.BlockHeaderByHeight => new GenericRequest
+                MoneroResponseSubType.BlockHeaderByHeight => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block_header_by_height",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.BlockHeaderByRange => new GenericRequest
+                MoneroResponseSubType.BlockHeaderByRange => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block_headers_range",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.BlockHeaderByRecency => new GenericRequest
+                MoneroResponseSubType.BlockHeaderByRecency => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_last_block_header",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AllConnections => new GenericRequest
+                MoneroResponseSubType.AllConnections => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_connections",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.NodeInformation => new GenericRequest
+                MoneroResponseSubType.NodeInformation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_info",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.HardforkInformation => new GenericRequest
+                MoneroResponseSubType.HardforkInformation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "hard_fork_info",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.BanInformation => new GenericRequest
+                MoneroResponseSubType.BanInformation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_bans",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.FlushTransactionPool => new GenericRequest
+                MoneroResponseSubType.FlushTransactionPool => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "flush_txpool",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.OutputHistogram => new GenericRequest
+                MoneroResponseSubType.OutputHistogram => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_output_histogram",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.CoinbaseTransactionSum => new GenericRequest
+                MoneroResponseSubType.CoinbaseTransactionSum => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_coinbase_tx_sum",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.FeeEstimate => new GenericRequest
+                MoneroResponseSubType.FeeEstimate => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_fee_estimate",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AlternateChain => new GenericRequest
+                MoneroResponseSubType.AlternateChain => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_alternate_chains",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.RelayTransaction => new GenericRequest
+                MoneroResponseSubType.RelayTransaction => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "relay_tx",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SyncInformation => new GenericRequest
+                MoneroResponseSubType.SyncInformation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sync_info",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Block => new GenericRequest
+                MoneroResponseSubType.Block => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SetBans => new GenericRequest
+                MoneroResponseSubType.SetBans => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "set_bans",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.DaemonVersion => new GenericRequest
+                MoneroResponseSubType.DaemonVersion => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_version",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Balance => new GenericRequest
+                MoneroResponseSubType.Balance => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_balance",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Address => new GenericRequest
+                MoneroResponseSubType.Address => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_address",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AddressIndex => new GenericRequest
+                MoneroResponseSubType.AddressIndex => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_address_index",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AddressCreation => new GenericRequest
+                MoneroResponseSubType.AddressCreation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "create_address",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AddressLabeling => new GenericRequest
+                MoneroResponseSubType.AddressLabeling => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "label_address",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Account => new GenericRequest
+                MoneroResponseSubType.Account => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_accounts",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountCreation => new GenericRequest
+                MoneroResponseSubType.AccountCreation => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "create_account",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountLabeling => new GenericRequest
+                MoneroResponseSubType.AccountLabeling => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "label_account",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountTags => new GenericRequest
+                MoneroResponseSubType.AccountTags => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_account_tags",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountTagging => new GenericRequest
+                MoneroResponseSubType.AccountTagging => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "tag_accounts",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountUntagging => new GenericRequest
+                MoneroResponseSubType.AccountUntagging => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "untag_accounts",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AccountTagAndDescriptionSetting => new GenericRequest
+                MoneroResponseSubType.AccountTagAndDescriptionSetting => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "set_account_tag_description",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Height => new GenericRequest
+                MoneroResponseSubType.Height => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_height",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.FundTransfer => new GenericRequest
+                MoneroResponseSubType.FundTransfer => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "transfer",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.FundTransferSplit => new GenericRequest
+                MoneroResponseSubType.FundTransferSplit => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "transfer_split",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SignTransfer => new GenericRequest
+                MoneroResponseSubType.SignTransfer => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sign_transfer",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SweepDust => new GenericRequest
+                MoneroResponseSubType.SweepDust => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sweep_dust",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SweepAll => new GenericRequest
+                MoneroResponseSubType.SweepAll => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sweep_all",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SaveWallet => new GenericRequest
+                MoneroResponseSubType.SaveWallet => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "store",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.StopWallet => new GenericRequest
+                MoneroResponseSubType.StopWallet => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "stop_wallet",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.IncomingTransfers => new GenericRequest
+                MoneroResponseSubType.IncomingTransfers => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "incoming_transfers",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.QueryPrivateKey => new GenericRequest
+                MoneroResponseSubType.QueryPrivateKey => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "query_key",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SetTransactionNotes => new GenericRequest
+                MoneroResponseSubType.SetTransactionNotes => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "set_tx_notes",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetTransactionNotes => new GenericRequest
+                MoneroResponseSubType.GetTransactionNotes => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_tx_notes",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetTransactionKey => new GenericRequest
+                MoneroResponseSubType.GetTransactionKey => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_tx_key",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.CheckTransactionKey => new GenericRequest
+                MoneroResponseSubType.CheckTransactionKey => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "check_tx_key",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Transfers => new GenericRequest
+                MoneroResponseSubType.Transfers => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_transfers",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.TransferByTxid => new GenericRequest
+                MoneroResponseSubType.TransferByTxid => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_transfer_by_txid",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Sign => new GenericRequest
+                MoneroResponseSubType.Sign => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sign",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ExportOutputs => new GenericRequest
+                MoneroResponseSubType.ExportOutputs => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "export_outputs",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ImportOutputs => new GenericRequest
+                MoneroResponseSubType.ImportOutputs => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "import_outputs",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ExportKeyImages => new GenericRequest
+                MoneroResponseSubType.ExportKeyImages => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "export_key_images",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ImportKeyImages => new GenericRequest
+                MoneroResponseSubType.ImportKeyImages => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "import_key_images",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.MakeUri => new GenericRequest
+                MoneroResponseSubType.MakeUri => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "make_uri",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ParseUri => new GenericRequest
+                MoneroResponseSubType.ParseUri => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "parse_uri",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetAddressBook => new GenericRequest
+                MoneroResponseSubType.GetAddressBook => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_address_book",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.AddAddressBook => new GenericRequest
+                MoneroResponseSubType.AddAddressBook => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "add_address_book",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.DeleteAddressBook => new GenericRequest
+                MoneroResponseSubType.DeleteAddressBook => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "delete_address_book",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Refresh => new GenericRequest
+                MoneroResponseSubType.Refresh => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "refresh",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.RescanSpent => new GenericRequest
+                MoneroResponseSubType.RescanSpent => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "rescan_spent",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.Languages => new GenericRequest
+                MoneroResponseSubType.Languages => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_languages",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.CreateWallet => new GenericRequest
+                MoneroResponseSubType.CreateWallet => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "create_wallet",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.OpenWallet => new GenericRequest
+                MoneroResponseSubType.OpenWallet => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "open_wallet",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.CloseWallet => new GenericRequest
+                MoneroResponseSubType.CloseWallet => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "close_wallet",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ChangeWalletPassword => new GenericRequest
+                MoneroResponseSubType.ChangeWalletPassword => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "change_wallet_password",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.RpcVersion => new GenericRequest
+                MoneroResponseSubType.RpcVersion => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_version",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.IsMultiSig => new GenericRequest
+                MoneroResponseSubType.IsMultiSig => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "is_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.PrepareMultiSig => new GenericRequest
+                MoneroResponseSubType.PrepareMultiSig => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "prepare_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.MakeMultiSig => new GenericRequest
+                MoneroResponseSubType.MakeMultiSig => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "make_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ExportMultiSigInfo => new GenericRequest
+                MoneroResponseSubType.ExportMultiSigInfo => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "export_multisig_info",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.ImportMultiSigInfo => new GenericRequest
+                MoneroResponseSubType.ImportMultiSigInfo => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "import_multisig_info",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.FinalizeMultiSig => new GenericRequest
+                MoneroResponseSubType.FinalizeMultiSig => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "finalize_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SignMultiSigTransaction => new GenericRequest
+                MoneroResponseSubType.SignMultiSigTransaction => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sign_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SubmitMultiSigTransaction => new GenericRequest
+                MoneroResponseSubType.SubmitMultiSigTransaction => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "submit_multisig",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.DescribeTransfer => new GenericRequest
+                MoneroResponseSubType.DescribeTransfer => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "describe_transfer",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SweepSingle => new GenericRequest
+                MoneroResponseSubType.SweepSingle => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "sweep_single",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetBlockTemplate => new GenericRequest
+                MoneroResponseSubType.GetBlockTemplate => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_block_template",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetBanStatus => new GenericRequest
+                MoneroResponseSubType.GetBanStatus => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "banned",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.PruneBlockchain => new GenericRequest
+                MoneroResponseSubType.PruneBlockchain => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "prune_blockchain",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.GetAttribute => new GenericRequest
+                MoneroResponseSubType.GetAttribute => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "get_attribute",
                     @params = requestParams,
                 },
-                MoneroResponseSubType.SetAttribute => new GenericRequest
+                MoneroResponseSubType.SetAttribute => new BaseRequest
                 {
+                    endpoint = RequestEndpoint.JsonRpc,
                     method = "set_attribute",
                     @params = requestParams,
                 },
@@ -464,12 +584,20 @@ namespace Monero.Client.Network
             };
         }
 
-        private static async Task<HttpRequestMessage> SerializeRequest(HttpRequestMessage httpRequestMessage, GenericRequest request, CancellationToken token)
+        private static async Task<HttpRequestMessage> SerializeRequest(HttpRequestMessage httpRequestMessage, CustomRequest request, CancellationToken token)
         {
             using var ms = new MemoryStream();
-            await JsonSerializer.SerializeAsync<GenericRequest>(ms, request, _defaultSerializationOptions, token).ConfigureAwait(false);
-            var messageContent = ms.ToArray();
-            httpRequestMessage.Content = new ByteArrayContent(messageContent);
+            await JsonSerializer.SerializeAsync<CustomRequest>(ms, request, _defaultSerializationOptions, token).ConfigureAwait(false);
+            httpRequestMessage.Content = new ByteArrayContent(ms.ToArray());
+            httpRequestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(FieldAndHeaderDefaults.ApplicationJson);
+            return httpRequestMessage;
+        }
+
+        private static async Task<HttpRequestMessage> SerializeRequest(HttpRequestMessage httpRequestMessage, BaseRequest request, CancellationToken token)
+        {
+            using var ms = new MemoryStream();
+            await JsonSerializer.SerializeAsync<BaseRequest>(ms, request, _defaultSerializationOptions, token).ConfigureAwait(false);
+            httpRequestMessage.Content = new ByteArrayContent(ms.ToArray());
             httpRequestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(FieldAndHeaderDefaults.ApplicationJson);
             return httpRequestMessage;
         }

--- a/Network/Request.cs
+++ b/Network/Request.cs
@@ -1,7 +1,11 @@
-﻿namespace Monero.Client.Network
+﻿using System.Text.Json.Serialization;
+
+namespace Monero.Client.Network
 {
     internal class Request
     {
+        [JsonIgnore()]
+        public RequestEndpoint endpoint { get; set; }
         public string jsonrpc { get; set; } = FieldAndHeaderDefaults.JsonRpc;
         public string id { get; set; } = FieldAndHeaderDefaults.Id;
     }

--- a/Network/RequestEndpoint.cs
+++ b/Network/RequestEndpoint.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Monero.Client.Network
+{
+    internal enum RequestEndpoint
+    {
+        // Generic endpoint
+        JsonRpc,
+        // Custom endpoints
+        // https://www.getmonero.org/resources/developer-guides/daemon-rpc.html#get_transaction_pool
+        TransactionPool,
+        Transactions,
+    }
+
+    internal class RequestEndpointExtensionRetriever
+    {
+        public static string FetchEndpoint(Request request)
+        {
+            return FetchEndpoint(request.endpoint);
+        }
+
+        public static string FetchEndpoint(RequestEndpoint endpoint)
+        {
+            return endpoint switch
+            {
+                RequestEndpoint.JsonRpc => "json_rpc",
+                RequestEndpoint.TransactionPool => "get_transaction_pool",
+                RequestEndpoint.Transactions => "get_transactions",
+                _ => throw new InvalidOperationException($"Unknown Endpoint ({endpoint})"),
+            };
+        }
+    }
+}

--- a/Network/UriBuilder.cs
+++ b/Network/UriBuilder.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Monero.Client.Network
+{
+    internal interface IUriBuilder
+    {
+        Uri Build();
+    }
+
+    internal class UriBuilder : IUriBuilder
+    {
+        private readonly string _url;
+        private readonly string _endpoint;
+        private readonly uint _port;
+        
+        public UriBuilder(string url, uint port, string endpoint)
+        {
+            _url = url;
+            _port = port;
+            _endpoint = endpoint;
+        }
+
+        public Uri Build()
+        {
+            return new Uri($"http://{_url}:{_port}/{_endpoint}");
+        }
+    }
+
+    internal class UriBuilderDirector : IUriBuilder
+    {
+        private readonly IUriBuilder _uriBuilder;
+
+        public UriBuilderDirector(IUriBuilder uriBuilder)
+        {
+            _uriBuilder = uriBuilder;
+        }
+
+        public Uri Build()
+        {
+            return _uriBuilder.Build();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Both a daemon client and wallet client are available. The daemon client interact
 **Initialize Client**
 ```csharp
 using Monero.Client.Daemon;
-var daemonClient = await MoneroDaemonClient.CreateAsync(new Uri("http://127.0.0.1:18082/json_rpc")).ConfigureAwait(false);
+var daemonClient = await MoneroDaemonClient.CreateAsync("127.0.0.1",18081);
 ```
 **Get Connections**
 ```csharp
-List<Connection> connections = await daemonClient.GetConnectionsAsync().ConfigureAwait(false);
+List<Connection> connections = await daemonClient.GetConnectionsAsync();
 ```
 ![](gif/connectionsdemo.gif)
 For the entire MoneroDaemonClient interface, please click [here](https://github.com/Agorist-Action/csharp-monero-rpc-client/blob/master/Daemon/IMoneroDaemonClient.cs).
@@ -25,16 +25,8 @@ using Monero.Client.Network;
 using Monero.Client.Wallet;
 using Monero.Client.Wallet.POD;
 
-// Synchronously Initialize Client
-var moneroWalletClient = new MoneroWalletClient(new Uri("http://127.0.0.1:18082/json_rpc"));
-
-// Asynchronously Initialize Client (and Open Wallet) - This is the preferred method of initialization.
-var walletClient = await MoneroWalletClient.CreateAsync(MoneroNetwork.Mainnet, "TestMainnet", "123").ConfigureAwait(false);
-```
-**Open Wallet**
-```csharp
-// Will throw if wallet is already open.
-await moneroWalletClient.OpenWalletAsync("new_wallet3", "banana").ConfigureAwait(false);
+// Asynchronously Initialize Client (and Open Wallet)
+var walletClient = await MoneroWalletClient.CreateAsync(MoneroNetwork.Mainnet, "TestMainnet", "123");
 ```
 **Transfer Funds**
 ```csharp
@@ -43,7 +35,7 @@ var dA = new List<(string address, ulong amount)>()
 	("BfukYd1Dv5YDgkZDhffjmHb1SfzT7Wr1HNTYkyxEmfnXiGepCHgPiaWicRCLHpM2moVNWAxNEVKogU2w58fT", 1000ul),
 	("SomeOtherMoneroAddress", 3233100ul),
 };
-var response = await moneroWalletClient.TransferAsync(dA, TransferPriority.Normal).ConfigureAwait(false);
+var response = await moneroWalletClient.TransferAsync(dA, TransferPriority.Normal);
 ```
 For the entire MoneroWalletClient interface, please click [here](https://github.com/monero-ecosystem/csharp-monero-rpc-client/blob/master/Wallet/IMoneroWalletClient.cs).
 **Note:** Unlike the Daemon Client, to perform any action with the Wallet Client, one must first either create a new wallet, or open an existing one (as shown above).

--- a/Utilities/ErrorGuard.cs
+++ b/Utilities/ErrorGuard.cs
@@ -30,7 +30,7 @@ namespace Monero.Client.Utilities
         public static void ThrowIfResultIsNull(RpcResponse rpcResponse, string functionName)
         {
             StringBuilder errorMessageBuilder = new StringBuilder($"Error experienced when making RPC call in {functionName}.");
-            if (rpcResponse == null)
+            if (rpcResponse == null || rpcResponse.Id == null || rpcResponse.JsonRpc == null)
                 throw new JsonRpcException(errorMessageBuilder.ToString());
             else if (rpcResponse.ContainsError)
             {

--- a/Wallet/MoneroWalletClient.cs
+++ b/Wallet/MoneroWalletClient.cs
@@ -16,25 +16,15 @@ namespace Monero.Client.Wallet
         private readonly object _disposingLock = new object();
         private bool _disposed = false;
 
-        public MoneroWalletClient(Uri uri)
+        private MoneroWalletClient(string url, uint port)
         {
-            _moneroRpcCommunicator = new RpcCommunicator(uri);
-        }
-
-        public MoneroWalletClient(Uri uri, HttpMessageHandler httpMessageHandler)
-        {
-            _moneroRpcCommunicator = new RpcCommunicator(uri, httpMessageHandler);
-        }
-
-        public MoneroWalletClient(Uri uri, HttpMessageHandler httpMessageHandler, bool disposeHandler)
-        {
-            _moneroRpcCommunicator = new RpcCommunicator(uri, httpMessageHandler, disposeHandler);
+            _moneroRpcCommunicator = new RpcCommunicator(url, port);
         }
 
         /// <summary>
         /// Initialize a Monero Wallet Client using default network settings (<localhost>:<defaultport>)
         /// </summary>
-        public MoneroWalletClient(MoneroNetwork networkType)
+        private MoneroWalletClient(MoneroNetwork networkType)
         {
             _moneroRpcCommunicator = new RpcCommunicator(networkType, ConnectionType.Wallet);
         }
@@ -42,9 +32,9 @@ namespace Monero.Client.Wallet
         /// <summary>
         /// Initialize a Monero Wallet Client using default network settings (<localhost>:<defaultport>), opening the wallet while doing so.
         /// </summary>
-        public static Task<MoneroWalletClient> CreateAsync(Uri uri, string filename, string password, CancellationToken cancellationToken = default)
+        public static Task<MoneroWalletClient> CreateAsync(string url, uint port, string filename, string password, CancellationToken cancellationToken = default)
         {
-            var moneroWalletClient = new MoneroWalletClient(uri);
+            var moneroWalletClient = new MoneroWalletClient(url, port);
             return moneroWalletClient.InitializeAsync(filename, password, cancellationToken);
         }
 

--- a/Wallet/POD/Responses/ShowTransfersResponse.cs
+++ b/Wallet/POD/Responses/ShowTransfersResponse.cs
@@ -123,7 +123,7 @@ namespace Monero.Client.Wallet.POD.Responses
         {
             get
             {
-                return new DateTime(1970, 1, 1).AddSeconds(this.Timestamp);
+                return DateTime.UnixEpoch.AddSeconds(this.Timestamp);
             }
         }
 


### PR DESCRIPTION
There are several non json-rpc calls I'd like to add to the Daemon client. They are [get_transaction_pool](https://www.getmonero.org/resources/developer-guides/daemon-rpc.html#get_transaction_pool) and get_transactions. To accomodate non json-rpc interface, there were some changes made internally.

See: UriBuilder, RequestEndpointExtensionRetriever, CustomRequestParameters, CustomRequest

From the user-experience perspective, all constructors are not private. Users can only create an instance of the object via the CreateAsync factory method. Also, instead of passing in a `Uri` (like `http://127.0.0.1:18081/json_rpc`), the user now passes in the Url and Port, like `MoneroDaemonClient.CreateAsync("127.0.0.1", 18081)`. This is to decouple the json_rpc interface from the Uri. Based on the request the user sends, the UriBuilder will be responsible for creating the right Uri to hit, given the Url, and Port. 

Here's an example of fetching transaction pool transactions.

https://user-images.githubusercontent.com/74153025/116819816-5d316000-ab37-11eb-9f7a-de946adce4b9.mp4


Each transaction pool transaction has a `TxJson` field which seems to have a lot more detail about that transaction. I added a class below (which isn't complete but snuck into this MR) called `TransactionDetails`. I plan to add a method to a `TransactionPoolTransaction` which deserializes this `TxJson` json property into a `TransactionDetails` object. I'm not sure whether it should be a singleton (repeated calls to `.GetTransactionDetails()` returns the same instance of `TransactionDetails`) or not. Thoughts?


@rbrunner7 